### PR TITLE
Fix execution of DML queries.

### DIFF
--- a/nsdbsqlite.c
+++ b/nsdbsqlite.c
@@ -210,7 +210,12 @@ DbExec(Ns_DbHandle *handle, char *sql)
 
     if (contextPtr->ncolumns == 0) { 
         handle->fetchingRows = NS_FALSE;
-        status = NS_DML;
+        /* for DML queries need to run sqlite3_step to execute  */
+        if (sqlite3_step(contextPtr->stmt) != SQLITE_DONE) {
+	    status = NS_ERROR;
+        } else {
+            status = NS_DML;
+        }
     } else {
         handle->fetchingRows = NS_TRUE;
         status = NS_ROWS;


### PR DESCRIPTION
DML queries like UPDATE doesn't really executed, only prepared. To execute it, call sqlite3_step.
